### PR TITLE
Rename descriptor yaml element `file_names` to `file_names_regex`

### DIFF
--- a/.automation/build.py
+++ b/.automation/build.py
@@ -270,9 +270,9 @@ def generate_descriptor_documentation(descriptor):
         for file_extension in descriptor.get("file_extensions"):
             descriptor_md += [f"  - `{file_extension}`"]
         descriptor_md += [""]
-    if len(descriptor.get("file_names", [])) > 0:
+    if len(descriptor.get("file_names_regex", [])) > 0:
         descriptor_md += ["- File names:"]
-        for file_name in descriptor.get("file_names"):
+        for file_name in descriptor.get("file_names_regex"):
             descriptor_md += [f"  - `{file_name}`"]
         descriptor_md += [""]
     if len(descriptor.get("file_contains_regex", [])) > 0:
@@ -562,9 +562,9 @@ def process_type(linters_by_type, type1, type_label, linters_tables_md):
             for file_extension in linter.file_extensions:
                 linter_doc_md += [f"  - `{file_extension}`"]
             linter_doc_md += [""]
-        if len(linter.file_names) > 0:
+        if len(linter.file_names_regex) > 0:
             linter_doc_md += ["- File names:"]
-            for file_name in linter.file_names:
+            for file_name in linter.file_names_regex:
                 linter_doc_md += [f"  - `{file_name}`"]
             linter_doc_md += [""]
         if len(linter.file_contains_regex) > 0:

--- a/docs/descriptor-schema.md
+++ b/docs/descriptor-schema.md
@@ -37,7 +37,7 @@ _Descriptor definition for mega-linter_
 	 - Default: ``
 		 - **_Items_**
 		 - Type: `string`
-- <b id="#http://github.com/nvuillam/megalinter.json/properties/file_names">file_names</b>
+- <b id="#http://github.com/nvuillam/megalinter.json/properties/file_names_regex">file_names_regex</b>
 	 - List of file names catch by the descriptor
 	 - _File name filter. Can be overridden at linter level_
 	 - Type: `array`
@@ -48,9 +48,9 @@ _Descriptor definition for mega-linter_
 		 - **_Items_**
 		 - Type: `string`
 
-- <b id="#http://github.com/nvuillam/megalinter.json/properties/file_contains">file_contains</b>
+- <b id="#http://github.com/nvuillam/megalinter.json/properties/file_contains_regex">file_contains_regex</b>
 	 - File content filters
-	 - _List of strings or regular expressions to filter the files according to their content_
+	 - _List of regular expressions to filter the files according to their content_
 	 - Type: `array`
 	 - Example values: 
 		 1. `AWSTemplateFormatVersion`

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -8,8 +8,8 @@ The following list of items can/must be overridden on custom linter local class:
 - field linter_url (required) ex: "https://eslint.org/"
 - field test_folder (optional) ex: "docker". If not set, language.lowercase() value is used
 - field config_file_name (optional) ex: ".eslintrc.yml". If not set, no default config file will be searched
-- field file_extensions (optional) ex: [".js"]. At least file_extension of file_names must be set
-- field file_names (optional) ex: ["Dockerfile"]. At least file_extension of file_names must be set
+- field file_extensions (optional) ex: [".js"]. At least file_extension or file_names_regex must be set
+- field file_names_regex (optional) ex: ["Dockerfile"]. At least file_extension or file_names_regex must be set
 - method build_lint_command (optional) : Return CLI command to lint a file with the related linter
                                          Default: linter_name + (if config_file(-c + config_file)) + config_file
 - method build_version_command (optional): Returns CLI command to get the related linter version.
@@ -54,7 +54,7 @@ class Linter:
         self.file_extensions = (
             []
         )  # Array of strings defining file extensions. Ex: ['.js','.cjs']
-        self.file_names = []  # Array of file names. Ex: ['Dockerfile']
+        self.file_names_regex = []  # Array of file names. Ex: ['Dockerfile']
         # Default name of the configuration file to use with the linter. Ex: '.eslintrc.js'
         self.config_file_name = None
         self.files_sub_directory = None
@@ -443,7 +443,7 @@ class Linter:
             self.file_extensions,
         )
         logging.debug(
-            "%s linter filter: %s: %s", self.name, "file_names", self.file_names
+            "%s linter filter: %s: %s", self.name, "file_names_regex", self.file_names_regex
         )
         logging.debug(
             "%s linter filter: %s: %s",
@@ -482,7 +482,7 @@ class Linter:
             elif (
                 self.lint_all_other_linters_files is False
                 and not megalinter.utils.check_file_extension_or_name(
-                    file, self.file_extensions, self.file_names
+                    file, self.file_extensions, self.file_names_regex
                 )
             ):
                 continue

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -75,7 +75,7 @@ class Megalinter:
         self.reporters = []
         self.linters = []
         self.file_extensions = []
-        self.file_names = []
+        self.file_names_regex = []
         self.status = "success"
         self.return_code = 0
         self.has_updated_sources = 0
@@ -95,7 +95,7 @@ class Megalinter:
         table_data = [["Descriptor", "Linter", "Criteria", "Matching files"]]
         for linter in self.linters:
             if len(linter.files) > 0:
-                all_criteria = linter.file_extensions + linter.file_names
+                all_criteria = linter.file_extensions + linter.file_names_regex
                 table_data += [
                     [
                         linter.descriptor_id,
@@ -325,12 +325,12 @@ class Megalinter:
     def compute_file_extensions(self):
         for linter in self.linters:
             self.file_extensions += linter.file_extensions
-            self.file_names += linter.file_names
+            self.file_names_regex += linter.file_names_regex
         # Remove duplicates
         self.file_extensions = list(
             collections.OrderedDict.fromkeys(self.file_extensions)
         )
-        self.file_names = list(collections.OrderedDict.fromkeys(self.file_names))
+        self.file_names_regex = list(collections.OrderedDict.fromkeys(self.file_names_regex))
 
     # Collect list of files matching extensions and regex
     def collect_files(self):
@@ -351,8 +351,8 @@ class Megalinter:
         # Filter files according to fileExtensions, fileNames , filterRegexInclude and filterRegexExclude
         if len(self.file_extensions) > 0:
             logging.info("- File extensions: " + ", ".join(self.file_extensions))
-        if len(self.file_names) > 0:
-            logging.info("- File names: " + ", ".join(self.file_names))
+        if len(self.file_names_regex) > 0:
+            logging.info("- File names: " + ", ".join(self.file_names_regex))
         if self.filter_regex_include is not None:
             logging.info("- Including regex: " + self.filter_regex_include)
         if self.filter_regex_exclude is not None:
@@ -374,7 +374,7 @@ class Megalinter:
                 continue
             elif file_extension in self.file_extensions:
                 filtered_files += [file]
-            elif filename in self.file_names:
+            elif filename in self.file_names_regex:
                 filtered_files += [file]
             elif "*" in self.file_extensions:
                 filtered_files += [file]

--- a/megalinter/descriptors/dockerfile.yml
+++ b/megalinter/descriptors/dockerfile.yml
@@ -1,7 +1,7 @@
 descriptor_id: DOCKERFILE
 descriptor_type: tooling_format
-file_names:
-  - "Dockerfile"
+file_names_regex:
+  - 'Dockerfile'
 test_folder: docker
 linters:
   # dockerfilelint

--- a/megalinter/descriptors/groovy.yml
+++ b/megalinter/descriptors/groovy.yml
@@ -5,8 +5,8 @@ file_extensions:
   - ".gvy"
   - ".gradle"
   - ".nf"
-file_names:
-  - Jenkinsfile
+file_names_regex:
+  - 'Jenkinsfile'
 linters:
   # npm-groovy-lint
   - class: GroovyNpmGroovyLintLinter

--- a/megalinter/descriptors/jsonschema.json
+++ b/megalinter/descriptors/jsonschema.json
@@ -54,8 +54,8 @@
         "type": "string"
       }
     },
-    "file_names": {
-      "$id": "#/properties/file_names",
+    "file_names_regex": {
+      "$id": "#/properties/file_names_regex",
       "type": "array",
       "title": "List of file names catch by the descriptor",
       "description": "File name filter. Can be overridden at linter level",

--- a/megalinter/descriptors/snakemake.yml
+++ b/megalinter/descriptors/snakemake.yml
@@ -2,8 +2,8 @@ descriptor_id: SNAKEMAKE
 descriptor_type: tooling_format
 file_extensions:
   - ".smk"
-file_names:
-  - "Snakefile"
+file_names_regex:
+  - 'Snakefile'
 linters:
   # Internal snakemake linter
   - linter_name: snakemake

--- a/megalinter/tests/test_megalinter/helpers/utilstest.py
+++ b/megalinter/tests/test_megalinter/helpers/utilstest.py
@@ -125,9 +125,9 @@ def test_linter_success(linter, test_self):
     )
     # Check console output
     if linter.cli_lint_mode == "file":
-        if len(linter.file_names) > 0 and len(linter.file_extensions) == 0:
+        if len(linter.file_names_regex) > 0 and len(linter.file_extensions) == 0:
             test_self.assertRegex(
-                output, rf"\[{linter_name}\] .*{linter.file_names[0]}.* - SUCCESS"
+                output, rf"\[{linter_name}\] .*{linter.file_names_regex[0]}.* - SUCCESS"
             )
         else:
             test_self.assertRegex(output, rf"\[{linter_name}\] .*good.* - SUCCESS")
@@ -181,12 +181,12 @@ def test_linter_failure(linter, test_self):
     )
     # Check console output
     if linter.cli_lint_mode == "file":
-        if len(linter.file_names) > 0 and len(linter.file_extensions) == 0:
+        if len(linter.file_names_regex) > 0 and len(linter.file_extensions) == 0:
             test_self.assertRegex(
-                output, rf"\[{linter_name}\] .*{linter.file_names[0]}.* - ERROR"
+                output, rf"\[{linter_name}\] .*{linter.file_names_regex[0]}.* - ERROR"
             )
             test_self.assertNotRegex(
-                output, rf"\[{linter_name}\] .*{linter.file_names[0]}.* - SUCCESS"
+                output, rf"\[{linter_name}\] .*{linter.file_names_regex[0]}.* - SUCCESS"
             )
         else:
             test_self.assertRegex(output, rf"\[{linter_name}\] .*bad.* - ERROR")

--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -140,12 +140,12 @@ def build_linter(language, linter_name):
     return linters[0]
 
 
-def check_file_extension_or_name(file, file_extensions, file_names):
+def check_file_extension_or_name(file, file_extensions, file_names_regex):
     base_file_name = os.path.basename(file)
     filename, file_extension = os.path.splitext(base_file_name)
     if len(file_extensions) > 0 and file_extension in file_extensions:
         return True
-    elif len(file_names) > 0 and filename in file_names:
+    elif len(file_names_regex) > 0 and filename in file_names_regex:
         return True
     elif len(file_extensions) == 1 and file_extensions[0] == "*":
         return True


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Rename descriptor yaml element `file_names` to `file_names_regex`
This is a preparation pull request before changing implementation to support regular expressions in `file_names_regex`.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
