### PR TITLE
"quick build" mode for contributors

### DIFF
--- a/.automation/upload-docker.sh
+++ b/.automation/upload-docker.sh
@@ -7,7 +7,7 @@
 # NOTES: This script is used to upload a Dockerfile to DockerHub
 # under the GitHub organization
 # Its based on being built from a GitHub Action, but could be easily updated
-# To be ran in a different medium.
+# To be ran in a different medium
 #
 # PRE-Requirements:
 # - Dockerfile

--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -8,12 +8,10 @@
 # Globals #
 ###########
 GITHUB_WORKSPACE="${GITHUB_WORKSPACE}" # GitHub Workspace
-TAG="${TAG}"
 GITHUB_SHA="${GITHUB_SHA}"             # Sha used to create this branch
-TAG=${TAG:-$GITHUB_SHA}
 BUILD_DATE="${BUILD_DATE}"             # Date the container was built
-BUILD_REVISION="${TAG}"         # GitHub Sha
-BUILD_VERSION="${TAG}"          # Version of the container
+BUILD_REVISION="${GITHUB_SHA}"         # GitHub Sha
+BUILD_VERSION="${GITHUB_SHA}"          # Version of the container
 ORG_REPO="nvuillam/mega-linter"        # Org/repo
 ERROR=0                                # Error count
 
@@ -45,8 +43,7 @@ ValidateLabel() {
   ########################
   # Get the docker label #
   ########################
-  echo "Checking label for ${ORG_REPO}:${TAG}"
-  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${TAG}")
+  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${GITHUB_SHA}")
 
   ###################
   # Check the value #

--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -45,6 +45,7 @@ ValidateLabel() {
   ########################
   # Get the docker label #
   ########################
+  echo "Checking label for ${ORG_REPO}:${TAG}"
   LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${TAG}")
 
   ###################

--- a/.automation/validate-docker-labels.sh
+++ b/.automation/validate-docker-labels.sh
@@ -8,10 +8,12 @@
 # Globals #
 ###########
 GITHUB_WORKSPACE="${GITHUB_WORKSPACE}" # GitHub Workspace
+TAG="${TAG}"
 GITHUB_SHA="${GITHUB_SHA}"             # Sha used to create this branch
+TAG=${TAG:-$GITHUB_SHA}
 BUILD_DATE="${BUILD_DATE}"             # Date the container was built
-BUILD_REVISION="${GITHUB_SHA}"         # GitHub Sha
-BUILD_VERSION="${GITHUB_SHA}"          # Version of the container
+BUILD_REVISION="${TAG}"         # GitHub Sha
+BUILD_VERSION="${TAG}"          # Version of the container
 ORG_REPO="nvuillam/mega-linter"        # Org/repo
 ERROR=0                                # Error count
 
@@ -43,7 +45,7 @@ ValidateLabel() {
   ########################
   # Get the docker label #
   ########################
-  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${GITHUB_SHA}")
+  LABEL=$(docker inspect --format "{{ index .Config.Labels \"${CONTAINER_KEY}\" }}" "${ORG_REPO}:${TAG}")
 
   ###################
   # Check the value #

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,9 +39,9 @@ Draft pull requests are also welcome to get feedback early on, or if there is so
 The **Mega-Linter** has _CI/CT/CD_ configured utilizing **GitHub** Actions.
 
 - When a branch is created and code is pushed, a **GitHub** Action is triggered for building the new **Docker** container with the new codebase
-  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 15 minutes)
+  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 15 minutes): only python files are copied over nvuillam/mega-linter:test-YOURUSERNAME-YOURBRANCH or nvuillam/mega-linter:latest if a previous full run has not been performed yet
   - You can [filter the performed tests](https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests) by writing `TEST_KEYWORDS=my keywords` in the commit message body. Example: `TEST_KEYWORDS=kubernetes_kubeval_test`
-  - The last commit before the validation of a Pull Request must be a full build with full tests (about 30 minutes build)
+  - The last commit before the validation of a Pull Request must be a full build with all tests (about 45 minutes)
 - The **Docker** container is then ran against the _test cases_ to validate all code sanity
   - `.automation/test` contains all test cases for each language that should be validated
 - These **GitHub** Actions utilize the Checks API and Protected Branches to help follow the SDLC

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,6 +39,9 @@ Draft pull requests are also welcome to get feedback early on, or if there is so
 The **Mega-Linter** has _CI/CT/CD_ configured utilizing **GitHub** Actions.
 
 - When a branch is created and code is pushed, a **GitHub** Action is triggered for building the new **Docker** container with the new codebase
+  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 20 minutes build with all tests)
+  - You can [filter the performed tests](https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests) by writing `TEST_KEYWORDS=my keywords` in the commit message body. Example: `TEST_KEYWORDS=kubernetes_kubeval_test`
+  - The last commit before the validation of a Pull Request must be a full build with full tests (about 30 minutes build)
 - The **Docker** container is then ran against the _test cases_ to validate all code sanity
   - `.automation/test` contains all test cases for each language that should be validated
 - These **GitHub** Actions utilize the Checks API and Protected Branches to help follow the SDLC

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Draft pull requests are also welcome to get feedback early on, or if there is so
 The **Mega-Linter** has _CI/CT/CD_ configured utilizing **GitHub** Actions.
 
 - When a branch is created and code is pushed, a **GitHub** Action is triggered for building the new **Docker** container with the new codebase
-  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 20 minutes build with all tests)
+  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 15 minutes)
   - You can [filter the performed tests](https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests) by writing `TEST_KEYWORDS=my keywords` in the commit message body. Example: `TEST_KEYWORDS=kubernetes_kubeval_test`
   - The last commit before the validation of a Pull Request must be a full build with full tests (about 30 minutes build)
 - The **Docker** container is then ran against the _test cases_ to validate all code sanity

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -91,6 +91,7 @@ jobs:
              MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:latest"
              if docker_tag_exists nvuillam/mega-linter ${{steps.image_tag.outputs.tag}}; then
                 MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}"
+                echo "Reusing previously built image as base for quick build: ${MEGA_LINTER_BASE_IMAGE}"
              fi
              docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${GITHUB_SHA}" --build-arg "BUILD_VERSION=${GITHUB_SHA}" --build-arg "MEGALINTER_BASE_IMAGE=${MEGA_LINTER_BASE_IMAGE}" --no-cache -f "Dockerfile-quick" -t nvuillam/mega-linter:${{steps.image_tag.outputs.tag}} . | while read line ; do echo "$(date +'%H:%M:%S')| $line"; done;
         timeout-minutes: 30

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -115,6 +115,8 @@ jobs:
       ########################################
       - name: Run Docker label test cases
         if: "!contains(github.event.head_commit.message, 'quick build')"
+        env:
+          GITHUB_SHA: ${{steps.image_tag.outputs.tag}}
         shell: bash
         run: .automation/validate-docker-labels.sh
 

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -72,7 +72,7 @@ jobs:
         id: image_tag
         run: |
              BRANCH_NAME="${GITHUB_REF##*/}"
-             TAG="${GITHUB_ACTOR}-${BRANCH_NAME}"
+             TAG="test-${GITHUB_ACTOR}-${BRANCH_NAME}"
              echo "Tag name: ${TAG}"
              echo "::set-output name=tag::${TAG}"
 
@@ -85,6 +85,7 @@ jobs:
         shell: bash
         run: |
              function docker_tag_exists() {
+                 echo "Checking existence of https://index.docker.io/v1/repositories/$1/tags/$2"
                  curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
              }
              MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:latest"

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -125,14 +125,19 @@ jobs:
         shell: bash
         run: |
           export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS"
-          echo "CI_ENV=${CI_ENV}"
-          docker run $CI_ENV -e TEST_CASE_RUN=true -e OUTPUT_FORMAT=tap -e OUTPUT_FOLDER=${GITHUB_SHA} -e OUTPUT_DETAILS=detailed -e GITHUB_SHA=${GITHUB_SHA} -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}
+          TEST_KEYWORDS=""
+          if [[ "${{github.event.head_commit.message}}" == *"TEST_KEYWORDS="* ]]; then
+            TEST_KEYWORDS=$(echo "${{github.event.head_commit.message}}" | sed "s/^TEST_KEYWORDS=\(.*\)$/\1/" )
+            echo "Run only tests with keywords ${TEST_KEYWORDS}"
+          fi
+          docker run $CI_ENV -e TEST_CASE_RUN=true -e OUTPUT_FORMAT=tap -e OUTPUT_FOLDER=${GITHUB_SHA} -e OUTPUT_DETAILS=detailed -e GITHUB_SHA=${GITHUB_SHA} -e PAT="${{secrets.PAT}}" -e TEST_KEYWORDS="${TEST_KEYWORDS}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}
         timeout-minutes: 30
 
       #####################################
       # Run Linter against ALL code base  #
       #####################################
       - name: Run against all code base
+        if: "!contains(github.event.head_commit.message, 'quick build')"
         shell: bash
         run: docker run -e GITHUB_REPOSITORY="${{github.repository}}" -e GITHUB_SHA="${{github.sha}}" -e GITHUB_TOKEN="${{github.token}}" -e GITHUB_RUN_ID="${{github.run_id}}" -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}
         timeout-minutes: 10

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -65,19 +65,56 @@ jobs:
       - name: Get current date
         run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
 
+      ########################
+      # Build image tag name #
+      ########################
+      - name: Build image tag name
+        id: image_tag
+        run: |
+             BRANCH_NAME="${GITHUB_REF##*/}"
+             TAG="${GITHUB_ACTOR}-${BRANCH_NAME}"
+             echo "Tag name: ${TAG}"
+             echo "::set-output name=tag::${TAG}"
+
       ###################################
       # Build image locally for testing #
       ###################################
-      - name: Build image
-        id: docker_build
+      - name: Build image (quick)
+        if: "contains(github.event.head_commit.message, 'quick build')"
+        id: docker_build_quick
         shell: bash
-        run: docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${GITHUB_SHA}" --build-arg "BUILD_VERSION=${GITHUB_SHA}" --no-cache -t nvuillam/mega-linter:${GITHUB_SHA} . | while read line ; do echo "$(date +'%H:%M:%S')| $line"; done;
+        run: |
+             function docker_tag_exists() {
+                 curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+             }
+             MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:latest"
+             if docker_tag_exists nvuillam/mega-linter ${{steps.image_tag.outputs.tag}}; then
+                MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}"
+             fi
+             docker build --build-arg "BUILD_DATE=${BUILD_DATE}" --build-arg "BUILD_REVISION=${GITHUB_SHA}" --build-arg "BUILD_VERSION=${GITHUB_SHA}" --build-arg "MEGALINTER_BASE_IMAGE=${MEGA_LINTER_BASE_IMAGE}" --no-cache -f "Dockerfile-quick" -t nvuillam/mega-linter:${{steps.image_tag.outputs.tag}} . | while read line ; do echo "$(date +'%H:%M:%S')| $line"; done;
         timeout-minutes: 30
+
+      ######################
+      # Build image (full) #
+      ######################
+      - name: Build image (full) & push
+        if: "!contains(github.event.head_commit.message, 'quick build')"
+        env:
+          # Set the Env Vars
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE_REPO: nvuillam/mega-linter
+          IMAGE_VERSION: ${{steps.image_tag.outputs.tag}}
+          DOCKERFILE_PATH: Dockerfile
+          REGISTRY: Docker
+        shell: bash
+        run: .automation/upload-docker.sh || true
 
       ########################################
       # Validates the metadata docker labels #
       ########################################
       - name: Run Docker label test cases
+        if: "!contains(github.event.head_commit.message, 'quick build')"
         shell: bash
         run: .automation/validate-docker-labels.sh
 
@@ -89,7 +126,7 @@ jobs:
         run: |
           export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS"
           echo "CI_ENV=${CI_ENV}"
-          docker run $CI_ENV -e TEST_CASE_RUN=true -e OUTPUT_FORMAT=tap -e OUTPUT_FOLDER=${GITHUB_SHA} -e OUTPUT_DETAILS=detailed -e GITHUB_SHA=${GITHUB_SHA} -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${GITHUB_SHA}
+          docker run $CI_ENV -e TEST_CASE_RUN=true -e OUTPUT_FORMAT=tap -e OUTPUT_FOLDER=${GITHUB_SHA} -e OUTPUT_DETAILS=detailed -e GITHUB_SHA=${GITHUB_SHA} -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}
         timeout-minutes: 30
 
       #####################################
@@ -97,7 +134,7 @@ jobs:
       #####################################
       - name: Run against all code base
         shell: bash
-        run: docker run -e GITHUB_REPOSITORY="${{github.repository}}" -e GITHUB_SHA="${{github.sha}}" -e GITHUB_TOKEN="${{github.token}}" -e GITHUB_RUN_ID="${{github.run_id}}" -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${GITHUB_SHA}
+        run: docker run -e GITHUB_REPOSITORY="${{github.repository}}" -e GITHUB_SHA="${{github.sha}}" -e GITHUB_TOKEN="${{github.token}}" -e GITHUB_RUN_ID="${{github.run_id}}" -e PAT="${{secrets.PAT}}" -v ${GITHUB_WORKSPACE}:/tmp/lint nvuillam/mega-linter:${{steps.image_tag.outputs.tag}}
         timeout-minutes: 10
 
       # Upload Mega-Linter artifacts
@@ -127,4 +164,4 @@ jobs:
         run: cd mega-linter-runner && sudo npm ci && sudo npm link
       - name: Run mega-linter-runner tests
         if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }})
-        run: cd mega-linter-runner && MEGALINTER_RELEASE=${{github.sha}} MEGALINTER_NO_DOCKER_PULL=true npm run test
+        run: cd mega-linter-runner && MEGALINTER_RELEASE=${{steps.image_tag.outputs.tag}} MEGALINTER_NO_DOCKER_PULL=true npm run test

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Run Docker label test cases
         if: "!contains(github.event.head_commit.message, 'quick build')"
         env:
-          GITHUB_SHA: ${{steps.image_tag.outputs.tag}}
+          TAG: ${{steps.image_tag.outputs.tag}}
         shell: bash
         run: .automation/validate-docker-labels.sh
 
@@ -163,13 +163,13 @@ jobs:
 
       # Test mega-linter-runner with newly created image
       - name: Setup Node
-        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }})
+        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }}) && !contains(github.event.head_commit.message, 'quick build')
         uses: actions/setup-node@v2.1.3
         with:
           node-version: "12"
       - name: Install NPM dependencies
-        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }})
+        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }}) && !contains(github.event.head_commit.message, 'quick build')
         run: cd mega-linter-runner && sudo npm ci && sudo npm link
       - name: Run mega-linter-runner tests
-        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }})
+        if: ${{ steps.docker_build.outcome }} == 'success' && (${{ success() }} || ${{ failure() }}) && !contains(github.event.head_commit.message, 'quick build')
         run: cd mega-linter-runner && MEGALINTER_RELEASE=${{steps.image_tag.outputs.tag}} MEGALINTER_NO_DOCKER_PULL=true npm run test

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -111,16 +111,6 @@ jobs:
         shell: bash
         run: .automation/upload-docker.sh || true
 
-      ########################################
-      # Validates the metadata docker labels #
-      ########################################
-      - name: Run Docker label test cases
-        if: "!contains(github.event.head_commit.message, 'quick build')"
-        env:
-          TAG: ${{steps.image_tag.outputs.tag}}
-        shell: bash
-        run: .automation/validate-docker-labels.sh
-
       #####################################
       # Run Linter against Test code base #
       #####################################

--- a/.github/workflows/deploy-DEV.yml
+++ b/.github/workflows/deploy-DEV.yml
@@ -85,8 +85,8 @@ jobs:
         shell: bash
         run: |
              function docker_tag_exists() {
-                 echo "Checking existence of https://index.docker.io/v1/repositories/$1/tags/$2"
-                 curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+                 echo "Checking existence of https://hub.docker.com/v2/repositories/$1/tags/$2"
+                 curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
              }
              MEGA_LINTER_BASE_IMAGE="nvuillam/mega-linter:latest"
              if docker_tag_exists nvuillam/mega-linter ${{steps.image_tag.outputs.tag}}; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Note: Can be used using nvuillam/mega-linter@insiders in your mega-linter.yml fi
   - Add Install button for JetBrains IDEs extensions when available
   - Add a new page **All linters** listing all linters and references to Mega-Linter in their documentation
 
+  CI
+  - Use `quick build` and `TEST_KEYWORDS` in commit messages, to improve contributor experience
+
 ## [4.20.0] 2020-12-28
 
 - Flavors

--- a/Dockerfile-quick
+++ b/Dockerfile-quick
@@ -1,0 +1,53 @@
+################################################
+################################################
+## Dockerfile to run Mega-Linter (Quick mode) ##
+################################################
+################################################
+
+##################
+# Get base image #
+##################
+ARG MEGALINTER_BASE_IMAGE=nvuillam/mega-linter:latest
+FROM $MEGALINTER_BASE_IMAGE
+
+################################
+# Installs python dependencies #
+################################
+COPY megalinter /megalinter
+RUN python /megalinter/setup.py install
+
+#######################################
+# Copy scripts and rules to container #
+#######################################
+COPY megalinter/descriptors /megalinter-descriptors
+COPY TEMPLATES /action/lib/.automation
+
+###########################
+# Get the build arguments #
+###########################
+ARG BUILD_DATE
+ARG BUILD_REVISION
+ARG BUILD_VERSION
+
+#################################################
+# Set ENV values used for debugging the version #
+#################################################
+ENV BUILD_DATE=$BUILD_DATE
+ENV BUILD_REVISION=$BUILD_REVISION
+ENV BUILD_VERSION=$BUILD_VERSION
+
+ENV MEGALINTER_FLAVOR=all
+
+#########################################
+# Label the instance and set maintainer #
+#########################################
+LABEL maintainer="Nicolas Vuillamy <nicolas.vuillamy@gmail.com>" \
+      org.opencontainers.image.created=$BUILD_DATE \
+      org.opencontainers.image.revision=$BUILD_REVISION \
+      org.opencontainers.image.version=$BUILD_VERSION \
+      org.opencontainers.image.authors="Nicolas Vuillamy <nicolas.vuillamy@gmail.com>" \
+      org.opencontainers.image.url="https://nvuillam.github.io/mega-linter" \
+      org.opencontainers.image.source="https://github.com/nvuillam/mega-linter" \
+      org.opencontainers.image.documentation="https://nvuillam.github.io/mega-linter" \
+      org.opencontainers.image.vendor="Nicolas Vuillamy" \
+      org.opencontainers.image.description="Lint your code base with GitHub Actions (DEV VERSION)"

--- a/README.md
+++ b/README.md
@@ -620,13 +620,11 @@ _Note:_ IF you did not use `Mega-Linter` as GitHub Action name, please read [Git
 <!-- plugins-section-start -->
 ## Plugins
 
-You can implement your own descriptors and load them as plugins during Mega-Linter runtime
+### Use plugins
 
-- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [Mega-Linter Json Schema](https://github.com/nvuillam/mega-linter/blob/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json)
-- Descriptor format is exactly the same than [Mega-Linter embedded ones](https://github.com/nvuillam/mega-linter/tree/master/megalinter/descriptors)
-- Plugins must be hosted in a url containing **\*\*/mega-linter-plugin-\*\*/**
+Just add plugin URLs in `PLUGINS` property of `.mega-linter.yml`
 
-Example in `.mega-linter.yml`
+#### Example
 
 ```yaml
 PLUGINS:
@@ -634,6 +632,17 @@ PLUGINS:
   - https://raw.githubusercontent.com/cookiejar/mega-linter-plugin-cookietemple/master/cookietemple.megalinter-descriptor.yml
 ```
 
+### Create plugins
+
+You can implement your own descriptors and load them as plugins during Mega-Linter runtime
+
+- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [Mega-Linter Json Schema](https://github.com/nvuillam/mega-linter/blob/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json)
+- Descriptor format is exactly the same than [Mega-Linter embedded ones](https://github.com/nvuillam/mega-linter/tree/master/megalinter/descriptors)
+- Plugins must be hosted in a url containing **\*\*/mega-linter-plugin-\*\*/**
+
+#### Limitations
+
+- For now, the only `install` attributes managed are `dockerfile` instructions starting by `RUN`
 <!-- plugins-section-end -->
 
 <!-- frequently-asked-questions-section-start -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@ Note: Can be used using nvuillam/mega-linter@insiders in your mega-linter.yml fi
   - Add Install button for JetBrains IDEs extensions when available
   - Add a new page **All linters** listing all linters and references to Mega-Linter in their documentation
 
+  CI
+  - Use `quick build` and `TEST_KEYWORDS` in commit messages, to improve contributor experience
+
 ## [4.20.0] 2020-12-28
 
 - Flavors

--- a/docs/all_linters.md
+++ b/docs/all_linters.md
@@ -32,7 +32,7 @@
 | **htmlhint** | 0.14.2 | [HTML](descriptors/html_htmlhint.md) | :hammer_and_wrench: | [Pull Request](https://github.com/htmlhint/HTMLHint/pull/579/files){target=_blank} |
 | **isort** | 5.7.0 | [PYTHON](descriptors/python_isort.md) | :white_circle: | [Repository](https://github.com/PyCQA/isort){target=_blank} |
 | **jscpd** | 3.3.23 | [COPYPASTE](descriptors/copypaste_jscpd.md) | :heart: | [Mega-Linter reference](https://github.com/kucherenko/jscpd#who-uses-jscpd){target=_blank} |
-| **jsonlint** | 1.6.3 | [JSON](descriptors/json_jsonlint.md) | :no_entry_sign: | [Web Site](https://github.com/zaach/jsonlint){target=_blank} |
+| **jsonlint** | 1.6.3 | [JSON](descriptors/json_jsonlint.md) | :hammer_and_wrench: | [Pull Request](https://github.com/zaach/jsonlint/pull/127){target=_blank} |
 | **ktlint** | 0.40.0 | [KOTLIN](descriptors/kotlin_ktlint.md) | :heart: | [Mega-Linter reference](https://github.com/pinterest/ktlint#-with-continuous-integration){target=_blank} |
 | **kubeval** | 0.15.0 | [KUBERNETES](descriptors/kubernetes_kubeval.md) | :white_circle: | [Repository](https://github.com/instrumenta/kubeval){target=_blank} |
 | **lintr** | 2.0.1.9000 | [R](descriptors/r_lintr.md) | :white_circle: | [Web Site](https://github.com/jimhester/lintr){target=_blank} |
@@ -70,6 +70,6 @@
 | **terragrunt** | 0.26.7 | [TERRAFORM](descriptors/terraform_terragrunt.md) | :white_circle: | [Repository](https://github.com/gruntwork-io/terragrunt){target=_blank} |
 | **terrascan** | 1.2.0 | [TERRAFORM](descriptors/terraform_terrascan.md) | :white_circle: | [Repository](https://github.com/accurics/terrascan){target=_blank} |
 | **tflint** | 0.22.0 | [TERRAFORM](descriptors/terraform_tflint.md) | :white_circle: | [Web Site](https://github.com/terraform-linters/tflint){target=_blank} |
-| **v8r** | 0.4.0 | [JSON](descriptors/json_v8r.md)<br/> [YAML](descriptors/yaml_v8r.md) | :white_circle: | [Web Site](https://github.com/chris48s/v8r){target=_blank} |
+| **v8r** | 0.4.0 | [JSON](descriptors/json_v8r.md)<br/> [YAML](descriptors/yaml_v8r.md) | :no_entry_sign: | [Web Site](https://github.com/chris48s/v8r){target=_blank} |
 | **xmllint** | 20910 | [XML](descriptors/xml_xmllint.md) | :white_circle: | [Web Site](http://xmlsoft.org/xmllint.html){target=_blank} |
 | **yamllint** | 1.25.0 | [YAML](descriptors/yaml_yamllint.md) | :no_entry_sign: | [Repository](https://github.com/adrienverge/yamllint){target=_blank} |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,13 +4,11 @@
 
 # Plugins
 
-You can implement your own descriptors and load them as plugins during Mega-Linter runtime
+## Use plugins
 
-- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [Mega-Linter Json Schema](https://github.com/nvuillam/mega-linter/blob/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json)
-- Descriptor format is exactly the same than [Mega-Linter embedded ones](https://github.com/nvuillam/mega-linter/tree/master/megalinter/descriptors)
-- Plugins must be hosted in a url containing **\*\*/mega-linter-plugin-\*\*/**
+Just add plugin URLs in `PLUGINS` property of `.mega-linter.yml`
 
-Example in `.mega-linter.yml`
+### Example
 
 ```yaml
 PLUGINS:
@@ -18,5 +16,16 @@ PLUGINS:
   - https://raw.githubusercontent.com/cookiejar/mega-linter-plugin-cookietemple/master/cookietemple.megalinter-descriptor.yml
 ```
 
+## Create plugins
+
+You can implement your own descriptors and load them as plugins during Mega-Linter runtime
+
+- Plugins descriptor files must be named **\*\*.megalinter-descriptor.yml** and respect [Mega-Linter Json Schema](https://github.com/nvuillam/mega-linter/blob/master/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json)
+- Descriptor format is exactly the same than [Mega-Linter embedded ones](https://github.com/nvuillam/mega-linter/tree/master/megalinter/descriptors)
+- Plugins must be hosted in a url containing **\*\*/mega-linter-plugin-\*\*/**
+
+### Limitations
+
+- For now, the only `install` attributes managed are `dockerfile` instructions starting by `RUN`
 
 <!-- plugins-section-end -->

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,11 @@ fi
 if [ "${TEST_CASE_RUN}" == "true" ]; then
   # Run test cases with pytest
   echo "RUNNING TEST CASES"
-  pytest -v --timeout=60 --durations=0 --cov=megalinter --cov-report=xml megalinter/
+  if [ -z "${TEST_KEYWORDS}" ]; then
+    pytest -v --timeout=60 --durations=0 --cov=megalinter --cov-report=xml megalinter/
+  else
+    pytest -v --timeout=60 --durations=0 -k "${TEST_KEYWORDS}" megalinter/
+  fi
   PYTEST_STATUS=$?
   echo Pytest exited $PYTEST_STATUS
   # Manage return code

--- a/megalinter/descriptors/json.megalinter-descriptor.yml
+++ b/megalinter/descriptors/json.megalinter-descriptor.yml
@@ -9,7 +9,7 @@ linters:
   # JSONLINT
   - linter_name: jsonlint
     linter_url: https://github.com/zaach/jsonlint
-    linter_megalinter_ref_url: "no"
+    linter_megalinter_ref_url: https://github.com/zaach/jsonlint/pull/127
     version_command_return_code: 1
     examples:
       - "jsonlint myfile.json"
@@ -21,6 +21,7 @@ linters:
     linter_url: https://github.com/chris48s/v8r
     linter_text: v8r checks the validity of JSON/YAML files if they have a matching schema defined on [schemastore.org](https://www.schemastore.org/json/)
     linter_rules_url: https://www.schemastore.org/json/
+    linter_megalinter_ref_url: "no"
     cli_lint_extra_args:
       - "--ignore-errors"
     cli_help_arg_name: "--help"


### PR DESCRIPTION
Related to #217 

- When a branch is created and code is pushed, a **GitHub** Action is triggered for building the new **Docker** container with the new codebase
  - During development, if all you updated is python code, you can write `quick build` in the commit message body to benefit from a quicker build (about 15 minutes): only python files are copied over nvuillam/mega-linter:test-YOURUSERNAME-YOURBRANCH or nvuillam/mega-linter:latest if a previous full run has not been performed yet
  - You can [filter the performed tests](https://docs.pytest.org/en/stable/usage.html#specifying-tests-selecting-tests) by writing `TEST_KEYWORDS=my keywords` in the commit message body. Example: `TEST_KEYWORDS=kubernetes_kubeval_test`
  - The last commit before the validation of a Pull Request must be a full build with all tests (about 45 minutes)
