### PR TITLE
Fix active_only_if_file_found check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Note: Can be used with `nvuillam/mega-linter@insiders` in your GitHub Action mega-linter.yml file, or with `nvuillam/mega-linter@latest` docker image
 
+- Fixes
+  - [#269](https://github.com/nvuillam/mega-linter/issues/269) eslint: .eslintrc.yml is considered as found whereas it's not located in workspace root
+
 - Linter versions upgrades
 <!-- linter-versions-end -->
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 Note: Can be used with `nvuillam/mega-linter@insiders` in your GitHub Action mega-linter.yml file, or with `nvuillam/mega-linter@latest` docker image
 
+- Fixes
+  - [#269](https://github.com/nvuillam/mega-linter/issues/269) eslint: .eslintrc.yml is considered as found whereas it's not located in workspace root
+
 - Linter versions upgrades
 <!-- linter-versions-end -->
 

--- a/megalinter/Linter.py
+++ b/megalinter/Linter.py
@@ -19,7 +19,6 @@ The following list of items can/must be overridden on custom linter local class:
 
 """
 import errno
-import glob
 import logging
 import os
 import re
@@ -227,14 +226,12 @@ class Linter:
             if len(self.active_only_if_file_found) > 0:
                 is_found = False
                 for file_to_check in self.active_only_if_file_found:
-                    found_files = glob.glob(
-                        f"{self.workspace}/**/{file_to_check}", recursive=True,
-                    )
-                    if len(found_files) > 0:
+                    if os.path.isfile(f"{self.workspace}/{file_to_check}"):
                         is_found = True
+                        break
                 if is_found is False:
                     self.is_active = False
-                    logging.debug(
+                    logging.info(
                         f"[Activation] {self.name} has been set inactive, as none of these files has been found:"
                         f" {str(self.active_only_if_file_found)}"
                     )


### PR DESCRIPTION
- Fixes
  - [#269](https://github.com/nvuillam/mega-linter/issues/269) eslint: .eslintrc.yml is considered as found whereas it's not located in workspace root

Closes #269
