### PR TITLE
Exclude .terraform, .mypy_cache, and REPORT_OUTPUT_FOLDER

### DIFF
--- a/megalinter/utils.py
+++ b/megalinter/utils.py
@@ -45,11 +45,13 @@ def get_excluded_directories():
         ".git",
         ".jekyll-cache",
         ".pytest_cache",
+        ".mypy_cache",
         ".rbenv",
         ".venv",
+        ".terraform",
         ".terragrunt-cache",
         "node_modules",
-        "report",
+        config.get("REPORT_OUTPUT_FOLDER", "report"),
     ]
     excluded_dirs = config.get_list("EXCLUDED_DIRECTORIES", default_excluded_dirs)
     excluded_dirs += config.get_list("ADDITIONAL_EXCLUDED_DIRECTORIES", [])


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Excludes `.terraform` and `.mypy_cache` folders by default, as these are cache folders for Terraform and Python's `mypy` tool respectively
2. Exclude the `REPORT_OUTPUT_FOLDER` dir based on the config, instead of using a hard-coded `report` value

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
