### PR TITLE
Fix anchor link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [**Online Documentation Web Site which has a much easier user navigation tha
 ## Table of Contents
 
 - [Mega-Linter](#mega-linter)
-  - [Why Mega-Linter ?](#why_mega-linter)
+  - [Why Mega-Linter ?](#why-mega-linter)
   - [Quick start](#quick-start)
   - [Supported Linters](#supported-linters)
     - [Languages](#languages)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->


<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

It seems GitHub uses dashes instead of underscore for the anchor link:

![image](https://user-images.githubusercontent.com/44045911/118157804-962dd680-b44d-11eb-9277-da3161a9a980.png)


## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
