### PR TITLE
Fix terraform fmt & terragrunt hclfmt

### DIFF
--- a/.automation/test/sample_project_fixes/terraform_for_fixes_1.tf
+++ b/.automation/test/sample_project_fixes/terraform_for_fixes_1.tf
@@ -1,0 +1,3 @@
+locals {
+  foo =     "bar"
+}

--- a/.automation/test/sample_project_fixes/terragrunt_for_fixes_1.hcl
+++ b/.automation/test/sample_project_fixes/terragrunt_for_fixes_1.hcl
@@ -1,0 +1,3 @@
+locals {
+  foo =     "bar"
+}

--- a/megalinter/descriptors/rst.megalinter-descriptor.yml
+++ b/megalinter/descriptors/rst.megalinter-descriptor.yml
@@ -48,4 +48,4 @@ linters:
       pip:
         - "sphinx<4.0"  # Necessary until https://github.com/dzhu/rstfmt/issues/12 is resolved
         - rstfmt
-    version_extract_regex: "rstfmt (\\d+(\\.\\d+)+)"
+    version_extract_regex: "(?<=rstfmt )\\d+(\\.\\d+)+"

--- a/megalinter/descriptors/terraform.megalinter-descriptor.yml
+++ b/megalinter/descriptors/terraform.megalinter-descriptor.yml
@@ -84,7 +84,6 @@ linters:
       - "fmt"
       - "--diff"
       - "--check"
-    cli_lint_fix_arg_name: "--fix"
     cli_lint_fix_remove_args:
       - "--diff"
       - "--check"

--- a/megalinter/descriptors/terraform.megalinter-descriptor.yml
+++ b/megalinter/descriptors/terraform.megalinter-descriptor.yml
@@ -106,4 +106,4 @@ linters:
         - name: HashiCorp Terraform
           url: https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform
     test_folder: terraform_fmt
-    version_extract_regex: "Terraform v(\\d+(\\.\\d+)+)"
+    version_extract_regex: "(?<=Terraform v)\\d+(\\.\\d+)+"

--- a/megalinter/descriptors/terraform.megalinter-descriptor.yml
+++ b/megalinter/descriptors/terraform.megalinter-descriptor.yml
@@ -60,6 +60,8 @@ linters:
     cli_lint_extra_args:
       - "hclfmt"
       - "--terragrunt-check"
+    cli_lint_fix_remove_args:
+      - "--terragrunt-check"
     cli_lint_extra_args_after:
       - "--terragrunt-hclfmt-file"
     test_folder: terraform_terragrunt


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

- Fixes the auto fix functionality of both `terraform fmt` and `terragrunt hclfmt`
- Adds tests to validate both
- (Bonus) Fix version number extraction for `terraform-fmt` and `rstfmt` (I think?)

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
