### PR TITLE
Typo error in PHP linter names of README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,16 +657,16 @@ ENABLE: JAVASCRIPT,GROOVY
 DISABLE_LINTERS: JAVASCRIPT_STANDARD
 ```
 
-- Run all linters except PHP linters (PHP_BUILTIN, PHP_PCPCS, PHP_STAN, PHP_PSALM)
+- Run all linters except PHP linters (PHP_BUILTIN, PHP_PHPCS, PHP_PHPSTAN, PHP_PSALM)
 
 ```yaml
 DISABLE: PHP
 ```
 
-- Run all linters except PHP_STAN and PHP_PSALM linters
+- Run all linters except PHP_PHPSTAN and PHP_PSALM linters
 
 ```yaml
-DISABLE_LINTERS: PHP_STAN,PHP_PSALM
+DISABLE_LINTERS: PHP_PHPSTAN,PHP_PSALM
 ```
 
 ### Filter linted files


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #667 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Reviewing Maintainer
- [ `documentation`] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
