### PR TITLE
Add cli_lint_mode to golangci-lint

### DIFF
--- a/.automation/test/golang/golang_bad_01.go
+++ b/.automation/test/golang/golang_bad_01.go
@@ -1,3 +1,7 @@
+package main
+
 if len(in) == 0 {
-  return "", fmt.Errorf("Input is empty")
+	return "", fmt.Errorf("Input is empty")
 }
+
+sum(1, 2)

--- a/.automation/test/golang/golang_good_01.go
+++ b/.automation/test/golang/golang_good_01.go
@@ -4,4 +4,5 @@ import "fmt"
 
 func main() {
 	fmt.Println("hello world")
+	sum(1, 2)
 }

--- a/.automation/test/golang/golang_good_maths_01.go
+++ b/.automation/test/golang/golang_good_maths_01.go
@@ -1,0 +1,5 @@
+package main
+
+func sum(a int, b int) int {
+	return a + b
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note: Can be used with `nvuillam/mega-linter@insiders` in your GitHub Action meg
   - Fix mega-linter-runner --install when local folder path contain spaces
   - Upgrade mega-linter-runner dependencies (npm audit fix)
   - Better comments for generated .mega-linter.yml config file
+  - Add lint_mode to go-golangci-lint
 
 - Linter versions upgrades
   - [markdown-table-formatter](https://www.npmjs.com/package/markdown-table-formatter) from 1.1.0 to **1.2.0** on 2021-08-20

--- a/megalinter/descriptors/go.megalinter-descriptor.yml
+++ b/megalinter/descriptors/go.megalinter-descriptor.yml
@@ -21,6 +21,7 @@ linters:
     cli_lint_extra_args:
       - "run"
     cli_version_arg_name: "version"
+    cli_lint_mode: list_of_files
     version_extract_regex: "((\\d+(\\.\\d+)+)|(master))"
     examples:
       - "golangci-lint run myfile.go"


### PR DESCRIPTION
Currently, the golangci-lint linter will validate each go file individually, this causes a problem if the file is using a function or variable declared in a different file within the same package. To solve this, I've added the cli_lint_mode in the linter description and updated the tests slightly. 

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
