### PR TITLE
Remove unnecessary jq due to CVE-2016-407

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/ci_light/Dockerfile
+++ b/flavors/ci_light/Dockerfile
@@ -41,7 +41,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/dart/Dockerfile
+++ b/flavors/dart/Dockerfile
@@ -43,7 +43,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/documentation/Dockerfile
+++ b/flavors/documentation/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/dotnet/Dockerfile
+++ b/flavors/dotnet/Dockerfile
@@ -47,7 +47,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/go/Dockerfile
+++ b/flavors/go/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/java/Dockerfile
+++ b/flavors/java/Dockerfile
@@ -43,7 +43,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/javascript/Dockerfile
+++ b/flavors/javascript/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/php/Dockerfile
+++ b/flavors/php/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/python/Dockerfile
+++ b/flavors/python/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/ruby/Dockerfile
+++ b/flavors/ruby/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/rust/Dockerfile
+++ b/flavors/rust/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/salesforce/Dockerfile
+++ b/flavors/salesforce/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/scala/Dockerfile
+++ b/flavors/scala/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/swift/Dockerfile
+++ b/flavors/swift/Dockerfile
@@ -42,7 +42,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \

--- a/flavors/terraform/Dockerfile
+++ b/flavors/terraform/Dockerfile
@@ -45,7 +45,6 @@ RUN apk add --update --no-cache \
     go \
     gnupg \
     icu-libs \
-    jq \
     krb5-libs \
     libcurl libintl libssl1.1 libstdc++ \
     libffi-dev \


### PR DESCRIPTION
Clair check reporting that jq contains critical CVE-2016-407
https://nvd.nist.gov/vuln/detail/CVE-2016-4074
This might be false-positive https://github.com/quay/clair/issues/852
but anyway I didn't find anything which is using jq in the code,
I assume it is leftover from the previous code.