### PR TITLE
Create CLI command when installing megalinter Python package

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,5 +43,5 @@ else
   if [[ ${LOG_LEVEL} == "DEBUG" ]]; then
     printenv
   fi
-  python -m megalinter.run
+  mega-linter
 fi

--- a/megalinter/setup.py
+++ b/megalinter/setup.py
@@ -30,5 +30,10 @@ setup(
         "beautifulsoup4",
         "giturlparse",
     ],
+    entry_points={
+        'console_scripts': [
+            'mega-linter = megalinter.run',
+        ],
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
Adds a Python entry point console script, which allows to intuitively invoke the CLI.

Relates to #717.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
