### PR TITLE
Only invoke git fetch when default branch missing, and only fetch the default branch if so.

### DIFF
--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -486,7 +486,10 @@ class Megalinter:
         default_branch_remote = f"origin/{default_branch}"
         if default_branch_remote not in [ref.name for ref in repo.refs]:
             # Try to fetch default_branch from origin, because it isn't cached locally.
-            repo.git.fetch()
+            repo.git.fetch(
+                "origin",
+                f"refs/heads/{default_branch}:refs/remotes/{default_branch_remote}"
+            )
         diff = repo.git.diff(default_branch_remote, name_only=True)
         logging.info(f"Modified files:\n{diff}")
         all_files = list()

--- a/megalinter/MegaLinter.py
+++ b/megalinter/MegaLinter.py
@@ -483,8 +483,11 @@ class Megalinter:
         )
         repo = git.Repo(os.path.realpath(self.github_workspace))
         default_branch = config.get("DEFAULT_BRANCH", "master")
-        repo.git.fetch()
-        diff = repo.git.diff(f"origin/{default_branch}", name_only=True)
+        default_branch_remote = f"origin/{default_branch}"
+        if default_branch_remote not in [ref.name for ref in repo.refs]:
+            # Try to fetch default_branch from origin, because it isn't cached locally.
+            repo.git.fetch()
+        diff = repo.git.diff(default_branch_remote, name_only=True)
         logging.info(f"Modified files:\n{diff}")
         all_files = list()
         for diff_line in diff.splitlines():


### PR DESCRIPTION
Fixes #896.

## Proposed Changes

1. When running in incremental mode locally on a private repository, invoking `git fetch` fails because the Docker image doesn't have access to your personal SSH keys (or a TTY via which to enter your username and password). Running `git fetch` also prevents Mega-Linter from running offline, and weakens the protection offered by `git push --force-with-lease`. However, the fetch is needed when running in incremental mode on a clone that lacks `origin/<default_branch>`. Notably, v2+ of the GitHub Actions checkout action defaults to shallow clones of depth 1, which always lack `origin/<default_branch>`. The end user is responsible for ensuring that their clone has `origin/<default_branch>` when running in incremental mode locally.
2. Instruct git to only fetch the default branch. Improve performance of incremental mode when using clones that lack `origin/<default_branch>`. There is no need to fetch every single branch when we only compare against the default branch.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`